### PR TITLE
add bioconductor dependencies to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,10 +76,8 @@ jobs:
             R -e 'install.packages("covr")'
             R -e 'install.packages("devtools")'
             R -e 'devtools::install_github("cb4ds/DGEobj.utils@cran")'
-            R -e 'install.packages("canvasXpress")'
-            R -e 'install.packages("ggrepel")'
-            R -e 'install.packages("igraph")'
-            R -e 'install.packages("statmod")'
+            R -e 'install.packages("remotes")'
+            R -e 'remotes::install_deps(dependencies = TRUE)'
       - run:
           name: Session information and installed package versions
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           name: Install R dependencies
           command: |
             R -e 'install.packages("BiocManager")'
-            R -e 'BiocManager::install(c("limma", "edgeR", "qvalue", "sva", "GenomicRanges"))'
+            R -e 'BiocManager::install(c("limma", "edgeR", "qvalue", "sva", "GenomicRanges", "zFPKM", "RNASeqPower", "IHW"))'
             R -e 'install.packages("covr")'
             R -e 'install.packages("remotes")'
             R -e 'remotes::install_deps(dependencies = TRUE)'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,6 @@ jobs:
             R -e 'install.packages("BiocManager")'
             R -e 'BiocManager::install(c("limma", "edgeR"))'
             R -e 'install.packages("covr")'
-            R -e 'install.packages("devtools")'
-            R -e 'devtools::install_github("cb4ds/DGEobj.utils@cran")'
             R -e 'install.packages("remotes")'
             R -e 'remotes::install_deps(dependencies = TRUE)'
       - run:
@@ -74,8 +72,6 @@ jobs:
             R -e 'install.packages("BiocManager")'
             R -e 'BiocManager::install(c("limma", "edgeR"))'
             R -e 'install.packages("covr")'
-            R -e 'install.packages("devtools")'
-            R -e 'devtools::install_github("cb4ds/DGEobj.utils@cran")'
             R -e 'install.packages("remotes")'
             R -e 'remotes::install_deps(dependencies = TRUE)'
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,12 +25,10 @@ jobs:
           name: Install R dependencies
           command: |
             R -e 'install.packages("BiocManager")'
-            R -e 'BiocManager::install(c("limma", "edgeR"))'
+            R -e 'BiocManager::install(c("limma", "edgeR", "qvalue", "sva", "GenomicRanges"))'
             R -e 'install.packages("covr")'
             R -e 'install.packages("remotes")'
             R -e 'remotes::install_deps(dependencies = TRUE)'
-            R -e 'install.packages("DGEobj")'
-            R -e 'install.packages("DGEobj.utils")'
       - run:
           name: Session information and installed package versions
           command: |
@@ -72,12 +70,10 @@ jobs:
           name: Install R dependencies
           command: |
             R -e 'install.packages("BiocManager")'
-            R -e 'BiocManager::install(c("limma", "edgeR"))'
+            R -e 'BiocManager::install(c("limma", "edgeR", "qvalue", "sva", "GenomicRanges"))'
             R -e 'install.packages("covr")'
             R -e 'install.packages("remotes")'
             R -e 'remotes::install_deps(dependencies = TRUE)'
-            R -e 'install.packages("DGEobj")'
-            R -e 'install.packages("DGEobj.utils")'
       - run:
           name: Session information and installed package versions
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,8 @@ jobs:
             R -e 'install.packages("covr")'
             R -e 'install.packages("remotes")'
             R -e 'remotes::install_deps(dependencies = TRUE)'
+            R -e 'install.packages("DGEobj")'
+            R -e 'install.packages("DGEobj.utils")'
       - run:
           name: Session information and installed package versions
           command: |
@@ -74,6 +76,8 @@ jobs:
             R -e 'install.packages("covr")'
             R -e 'install.packages("remotes")'
             R -e 'remotes::install_deps(dependencies = TRUE)'
+            R -e 'install.packages("DGEobj")'
+            R -e 'install.packages("DGEobj.utils")'
       - run:
           name: Session information and installed package versions
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
           name: Install R dependencies
           command: |
             R -e 'install.packages("BiocManager")'
-            R -e 'BiocManager::install(c("limma", "edgeR", "qvalue", "sva", "GenomicRanges"))'
+            R -e 'BiocManager::install(c("limma", "edgeR", "qvalue", "sva", "GenomicRanges", "zFPKM", "RNASeqPower", "IHW"))'
             R -e 'install.packages("covr")'
             R -e 'install.packages("remotes")'
             R -e 'remotes::install_deps(dependencies = TRUE)'


### PR DESCRIPTION
remove - devtools::install_github("cb4ds/DGEobj.utils@cran") , this was how it was installed on Travis but we won't need this anymore because DGEobj.utils is on cran and we can use install.packages()

install all the dependencies and suggested bioconductor packages for DGEobj.utils and DGEobj.